### PR TITLE
feat(mongo): include Monarch ORM version in MongoDB handshake

### DIFF
--- a/.changeset/late-wasps-switch.md
+++ b/.changeset/late-wasps-switch.md
@@ -1,0 +1,5 @@
+---
+"monarch-orm": patch
+---
+
+Add client metadata to mongo client returned by createClient

--- a/src/database.ts
+++ b/src/database.ts
@@ -25,9 +25,10 @@ import type {
   Pretty,
 } from "./utils/type-helpers";
 
-export function createClient(uri: string, options?: MongoClientOptions) {
-  options = options || {};
-  options.driverInfo = { name: "Monarch ORM", version: version };
+export function createClient(uri: string, options: MongoClientOptions = {}) {
+  if (!options.driverInfo) {
+    options.driverInfo = { name: "Monarch ORM", version };
+  }
   return new MongoClient(uri, options);
 }
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,4 +1,5 @@
 import { MongoClient, type Db, type MongoClientOptions } from "mongodb";
+import { version } from "../package.json";
 import { Collection } from "./collection/collection";
 import type {
   BoolProjection,
@@ -25,6 +26,9 @@ import type {
 } from "./utils/type-helpers";
 
 export function createClient(uri: string, options?: MongoClientOptions) {
+  if (options) {
+    options.driverInfo = { name: "Monarch ORM", version: version };
+  }
   return new MongoClient(uri, options);
 }
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -26,9 +26,8 @@ import type {
 } from "./utils/type-helpers";
 
 export function createClient(uri: string, options?: MongoClientOptions) {
-  if (options) {
-    options.driverInfo = { name: "Monarch ORM", version: version };
-  }
+  options = options || {};
+  options.driverInfo = { name: "Monarch ORM", version: version };
   return new MongoClient(uri, options);
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "target": "ES2020",
     "module": "CommonJS",
     "outDir": "./dist",
-    "strict": true
+    "strict": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
The PR incorporates MongoDB's [wrapping client library](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md#supporting-wrapping-libraries) specification for the connection handshake to allow library details to be included in the metadata written to `mongos` or `mongod` logs.

For example, this change would allow server-side logs such as the following:

> {"t":{"$date":"2025-03-23T23:10:40.108Z"},"s":"I","c":"NETWORK","id":51800,"ctx":"conn16235","msg":"client metadata","attr":{"remote":"127.0.0.1:1094","client":"conn16235","doc":{"driver":{`"name":"nodejs|Monarch ORM"`,`"version":"6.12.0|0.8.0"`},"platform":"Node.js v18.18.2, LE","os":{"name":"linux","architecture":"x64","version":"5.15.133+","type":"Linux"}}}}

For anyone hosting clusters with connections coming from different applications this can help differentiate connections and facilitate log analysis.